### PR TITLE
Add the ability to register and receive webhooks

### DIFF
--- a/app/controllers/spree/webhooks_controller.rb
+++ b/app/controllers/spree/webhooks_controller.rb
@@ -1,0 +1,14 @@
+class Spree::WebhooksController < Spree::Api::BaseController
+  rescue_from(Spree::Webhook::WebhookNotFound) { head :not_found }
+
+  def receive
+    webhook = Spree::Webhook.find(params[:id])
+    payload = request.request_parameters["webhook"]
+
+    authorize! :receive, webhook
+
+    webhook.receive(payload)
+
+    head :ok
+  end
+end

--- a/app/models/spree/webhook.rb
+++ b/app/models/spree/webhook.rb
@@ -1,0 +1,19 @@
+class Spree::Webhook
+  include ActiveModel::Model
+  attr_accessor :handler, :id
+
+  WebhookNotFound = Class.new(StandardError)
+
+  def receive(payload)
+    handler.call(payload)
+  end
+
+  def self.find(id)
+    id = id.to_sym # normalize incoming ids
+
+    handler = SolidusWebhooks.config.find_webhook_handler(id) or
+      raise WebhookNotFound, "Cannot find a webhook handler for #{id.inspect}"
+
+    new(id: id, handler: handler)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Spree::Core::Engine.routes.draw do
-  # Add your extension routes here
+  post '/webhooks/:id', to: 'webhooks#receive', as: :receive_webhook
 end

--- a/lib/solidus_webhooks.rb
+++ b/lib/solidus_webhooks.rb
@@ -4,4 +4,5 @@ require 'solidus_core'
 require 'solidus_support'
 
 require 'solidus_webhooks/version'
+require 'solidus_webhooks/configuration'
 require 'solidus_webhooks/engine'

--- a/lib/solidus_webhooks/configuration.rb
+++ b/lib/solidus_webhooks/configuration.rb
@@ -1,0 +1,30 @@
+module SolidusWebhooks
+  class Configuration
+    def initialize
+      @handlers = {}
+    end
+
+    def register_webhook_handler(id, handler)
+      unless handler.respond_to? :call
+        raise Spree::Webhook::InvalidHandler,
+          "Please provide a handler that responds to #call, got: #{handler.inspect}"
+      end
+
+      @handlers[id.to_sym] = handler
+    end
+
+    def find_webhook_handler(id)
+      @handlers[id.to_sym]
+    end
+  end
+
+  def self.config
+    @config
+  end
+
+  def self.reset_config!
+    @config = Configuration.new
+  end
+
+  reset_config! # initialize the extension
+end

--- a/spec/features/can_register_a_handler_and_receive_webhooks_spec.rb
+++ b/spec/features/can_register_a_handler_and_receive_webhooks_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+RSpec.feature "Can register a handler and receive Webhooks", type: :request do
+  background do
+    SolidusWebhooks.reset_config!
+    SolidusWebhooks.config.register_webhook_handler :foo, foo_handler
+    SolidusWebhooks.config.register_webhook_handler :bar, bar_handler
+  end
+
+  let(:foo_payloads) { [] }
+  let(:bar_payloads) { [] }
+
+  let(:foo_handler) { ->(payload) { foo_payloads << payload } }
+  let(:bar_handler) { ->(payload) { bar_payloads << payload } }
+
+  let(:token) { create(:admin_user, spree_api_key: "123").spree_api_key }
+  let(:token_without_permission) { create(:user, spree_api_key: "456").spree_api_key }
+
+  scenario "calls the handler passing the payload" do
+    post "/webhooks/foo?token=#{token}", as: :json, params: {a: 123}
+    expect(response).to have_http_status(:ok)
+
+    post "/webhooks/foo?token=#{token}", as: :json, params: {b: 456}
+    expect(response).to have_http_status(:ok)
+
+    post "/webhooks/bar?token=#{token}", as: :json, params: {c: 789}
+    expect(response).to have_http_status(:ok)
+
+    expect(foo_payloads).to eq([{'a' => 123}, {'b' => 456}])
+    expect(bar_payloads).to eq([{'c' => 789}])
+  end
+
+  scenario "receives a bad handler id" do
+    post "/webhooks/baz?token=#{token}", as: :json, params: {a: 123}
+    expect(response).to have_http_status(:not_found)
+  end
+
+  scenario "refuses a bad token" do
+    post "/webhooks/baz?token=b4d-t0k3n", as: :json, params: {a: 123}
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  scenario "refuses a token without permissions" do
+    post "/webhooks/foo?token=#{token_without_permission}", as: :json, params: {a: 123}
+    expect(response).to have_http_status(:unauthorized)
+  end
+end


### PR DESCRIPTION
Provides comprehensive Webhook support for Solidus, with a simple and
powerful way to register them and route payloads to appropriate
actions, either synchronous or delayed.

See the README for more details on how it works.