### PR TITLE
Expose current_api_user to webhook handlers

### DIFF
--- a/app/controllers/spree/webhooks_controller.rb
+++ b/app/controllers/spree/webhooks_controller.rb
@@ -7,7 +7,7 @@ class Spree::WebhooksController < Spree::Api::BaseController
 
     authorize! :receive, webhook
 
-    webhook.receive(payload)
+    webhook.receive(payload, current_api_user)
 
     head :ok
   end

--- a/app/models/spree/webhook.rb
+++ b/app/models/spree/webhook.rb
@@ -4,8 +4,8 @@ class Spree::Webhook
 
   WebhookNotFound = Class.new(StandardError)
 
-  def receive(payload)
-    handler.call(payload)
+  def receive(payload, current_api_user)
+    handler.call(payload, current_api_user)
   end
 
   def self.find(id)

--- a/spec/features/can_register_a_handler_and_receive_webhooks_spec.rb
+++ b/spec/features/can_register_a_handler_and_receive_webhooks_spec.rb
@@ -10,8 +10,8 @@ RSpec.feature "Can register a handler and receive Webhooks", type: :request do
   let(:foo_payloads) { [] }
   let(:bar_payloads) { [] }
 
-  let(:foo_handler) { ->(payload) { foo_payloads << payload } }
-  let(:bar_handler) { ->(payload) { bar_payloads << payload } }
+  let(:foo_handler) { ->(payload, current_api_user) { foo_payloads << payload } }
+  let(:bar_handler) { ->(payload, current_api_user) { bar_payloads << payload } }
 
   let(:token) { create(:admin_user, spree_api_key: "123").spree_api_key }
   let(:token_without_permission) { create(:user, spree_api_key: "456").spree_api_key }


### PR DESCRIPTION
Some scenarios require information about the authenticated user associated with the
webhook event. Passing the `current_api_user` to the handler provides
context about the authenicated user (and more importantly, avoids having
to make a separate DB query for this information).