### PR TITLE
Expose current_api_user to webhook handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,20 @@ Spree::RoleConfiguration.configure do |config|
 end
 ```
 
+### Accessing the API User
+
+If you need to access the API user that is making the call to the webhook, you can just accept an additional argument in the callable handler.
+
+Example:
+
+```ruby
+SolidusWebhooks.config.register_webhook_handler :tracking_number, -> payload, user {
+  Rails.logger.info "Received payload from user #{user.email}: #{payload.to_json}"
+  # …
+}
+```
+
+
 Installation
 ------------
 

--- a/app/controllers/spree/webhooks_controller.rb
+++ b/app/controllers/spree/webhooks_controller.rb
@@ -4,10 +4,11 @@ class Spree::WebhooksController < Spree::Api::BaseController
   def receive
     webhook = Spree::Webhook.find(params[:id])
     payload = request.request_parameters["webhook"]
+    user = current_api_user
 
     authorize! :receive, webhook
 
-    webhook.receive(payload)
+    webhook.receive(payload, user)
 
     head :ok
   end

--- a/app/models/spree/webhook.rb
+++ b/app/models/spree/webhook.rb
@@ -4,8 +4,12 @@ class Spree::Webhook
 
   WebhookNotFound = Class.new(StandardError)
 
-  def receive(payload)
-    handler.call(payload)
+  def receive(payload, user)
+    if handler_arity == 1
+      handler.call(payload)
+    else
+      handler.call(payload, user)
+    end
   end
 
   def self.find(id)
@@ -15,5 +19,15 @@ class Spree::Webhook
       raise WebhookNotFound, "Cannot find a webhook handler for #{id.inspect}"
 
     new(id: id, handler: handler)
+  end
+
+  private
+
+  def handler_arity
+    if handler.respond_to?(:arity)
+      handler.arity
+    else
+      handler.method(:call).arity
+    end
   end
 end

--- a/spec/features/can_register_a_handler_and_receive_webhooks_spec.rb
+++ b/spec/features/can_register_a_handler_and_receive_webhooks_spec.rb
@@ -3,45 +3,73 @@ require 'spec_helper'
 RSpec.feature "Can register a handler and receive Webhooks", type: :request do
   background do
     SolidusWebhooks.reset_config!
-    SolidusWebhooks.config.register_webhook_handler :foo, foo_handler
-    SolidusWebhooks.config.register_webhook_handler :bar, bar_handler
+    SolidusWebhooks.config.register_webhook_handler :proc, proc_handler
+    SolidusWebhooks.config.register_webhook_handler :method, method_handler
+    SolidusWebhooks.config.register_webhook_handler :user, user_handler
+    SolidusWebhooks.config.register_webhook_handler :splat, splat_handler
+    SolidusWebhooks.config.register_webhook_handler :method_and_user, method_and_user_handler
   end
 
-  let(:foo_payloads) { [] }
-  let(:bar_payloads) { [] }
+  let(:proc_payloads) { [] }
+  let(:method_payloads) { [] }
+  let(:user_payloads) { [] }
+  let(:splat_payloads) { [] }
+  let(:method_and_user_payloads) { [] }
 
-  let(:foo_handler) { ->(payload) { foo_payloads << payload } }
-  let(:bar_handler) { ->(payload) { bar_payloads << payload } }
+  let(:proc_handler) { ->(payload) { proc_payloads << payload } }
+  let(:method_handler) { Struct.new(:payloads) do
+    def call(payload) payloads << payload end
+  end.new(method_payloads) }
+  let(:user_handler) { ->(payload, user) { user_payloads << [payload, user] } }
+  let(:splat_handler) { ->(*args) { splat_payloads << args } }
+  let(:method_and_user_handler) { Struct.new(:payloads) do
+    def call(payload, user) payloads << payload end
+  end.new(method_and_user_payloads) }
 
-  let(:token) { create(:admin_user, spree_api_key: "123").spree_api_key }
-  let(:token_without_permission) { create(:user, spree_api_key: "456").spree_api_key }
+  let(:authorized_user) { create(:admin_user, spree_api_key: "123") }
+  let(:authorized_token) { authorized_user.spree_api_key }
+
+  let(:unauthorized_user) { create(:user, spree_api_key: "456") }
+  let(:unauthorized_token) { unauthorized_user.spree_api_key }
 
   scenario "calls the handler passing the payload" do
-    post "/webhooks/foo?token=#{token}", as: :json, params: {a: 123}
+    post "/webhooks/proc?token=#{authorized_token}", as: :json, params: {a: 123}
     expect(response).to have_http_status(:ok)
 
-    post "/webhooks/foo?token=#{token}", as: :json, params: {b: 456}
+    post "/webhooks/proc?token=#{authorized_token}", as: :json, params: {b: 456}
     expect(response).to have_http_status(:ok)
 
-    post "/webhooks/bar?token=#{token}", as: :json, params: {c: 789}
+    post "/webhooks/method?token=#{authorized_token}", as: :json, params: {c: 789}
     expect(response).to have_http_status(:ok)
 
-    expect(foo_payloads).to eq([{'a' => 123}, {'b' => 456}])
-    expect(bar_payloads).to eq([{'c' => 789}])
+    post "/webhooks/user?token=#{authorized_token}", as: :json, params: {d: 012}
+    expect(response).to have_http_status(:ok)
+
+    post "/webhooks/splat?token=#{authorized_token}", as: :json, params: {e: 345}
+    expect(response).to have_http_status(:ok)
+
+    post "/webhooks/method_and_user?token=#{authorized_token}", as: :json, params: {f: 678}
+    expect(response).to have_http_status(:ok)
+
+    expect(proc_payloads).to eq([{'a' => 123}, {'b' => 456}])
+    expect(method_payloads).to eq([{'c' => 789}])
+    expect(user_payloads).to eq([[{'d' => 012}, authorized_user]])
+    expect(splat_payloads).to eq([[{'e' => 345}, authorized_user]])
+    expect(method_and_user_payloads).to eq([{'f' => 678}])
   end
 
   scenario "receives a bad handler id" do
-    post "/webhooks/baz?token=#{token}", as: :json, params: {a: 123}
+    post "/webhooks/abc?token=#{authorized_token}", as: :json, params: {a: 123}
     expect(response).to have_http_status(:not_found)
   end
 
   scenario "refuses a bad token" do
-    post "/webhooks/baz?token=b4d-t0k3n", as: :json, params: {a: 123}
+    post "/webhooks/user?token=b4d-t0k3n", as: :json, params: {a: 123}
     expect(response).to have_http_status(:unauthorized)
   end
 
   scenario "refuses a token without permissions" do
-    post "/webhooks/foo?token=#{token_without_permission}", as: :json, params: {a: 123}
+    post "/webhooks/proc?token=#{unauthorized_token}", as: :json, params: {a: 123}
     expect(response).to have_http_status(:unauthorized)
   end
 end


### PR DESCRIPTION
Some scenarios require information about the authenticated user
associated with the webhook event. Passing the `current_api_user` to the
handler provides context about the authenicated user (and more
importantly, avoids having to make a separate DB query for this
information).

Fixes #3 