### PR TITLE
Bump SolidusSupport to 0.8

### DIFF
--- a/solidus_webhooks.gemspec
+++ b/solidus_webhooks.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
-  spec.add_dependency 'solidus_support', '~> 0.6'
+  spec.add_dependency 'solidus_support', '~> 0.8'
 
   spec.add_development_dependency 'solidus_dev_support', '~> 2.2'
 end


### PR DESCRIPTION
This was not strictly necessary for Solidus 3.0, I just stumbled into the change while I was in there.