### PR TITLE
Allow Solidus 4

### DIFF
--- a/solidus_webhooks.gemspec
+++ b/solidus_webhooks.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
+  spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 5']
   spec.add_dependency 'solidus_support', '~> 0.6'
 
   spec.add_development_dependency 'solidus_dev_support', '~> 2.2'


### PR DESCRIPTION
Solidus Paypal Commerce Platform depends on this extension, so we need to update this dependency to use Paypal with Solidus 4.