### PR TITLE
Update links from solidusio-contrib to solidusio GH organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Changelog
 
-See https://github.com/solidusio-contrib/solidus_webhooks/releases or [OLD_CHANGELOG.md](OLD_CHANGELOG.md) for older versions.
+See https://github.com/solidusio/solidus_webhooks/releases or [OLD_CHANGELOG.md](OLD_CHANGELOG.md) for older versions.

--- a/OLD_CHANGELOG.md
+++ b/OLD_CHANGELOG.md
@@ -1,51 +1,51 @@
 # Changelog
 
-## [v0.3.0](https://github.com/solidusio-contrib/solidus_webhooks/tree/v0.3.0) (2021-04-20)
+## [v0.3.0](https://github.com/solidusio/solidus_webhooks/tree/v0.3.0) (2021-04-20)
 
-[Full Changelog](https://github.com/solidusio-contrib/solidus_webhooks/compare/v0.3.0...v0.3.0)
+[Full Changelog](https://github.com/solidusio/solidus_webhooks/compare/v0.3.0...v0.3.0)
 
 **Closed issues:**
 
-- Prepare Solidus Webhooks for Solidus 3.0 [\#8](https://github.com/solidusio-contrib/solidus_webhooks/issues/8)
+- Prepare Solidus Webhooks for Solidus 3.0 [\#8](https://github.com/solidusio/solidus_webhooks/issues/8)
 
 **Merged pull requests:**
 
-- Allow Solidus 3 [\#10](https://github.com/solidusio-contrib/solidus_webhooks/pull/10) ([kennyadsl](https://github.com/kennyadsl))
-- Reconcile master and v0.3.0 [\#7](https://github.com/solidusio-contrib/solidus_webhooks/pull/7) ([elia](https://github.com/elia))
-- Bump solidus\_support to ~\> 0.6 [\#6](https://github.com/solidusio-contrib/solidus_webhooks/pull/6) ([peterberkenbosch](https://github.com/peterberkenbosch))
+- Allow Solidus 3 [\#10](https://github.com/solidusio/solidus_webhooks/pull/10) ([kennyadsl](https://github.com/kennyadsl))
+- Reconcile master and v0.3.0 [\#7](https://github.com/solidusio/solidus_webhooks/pull/7) ([elia](https://github.com/elia))
+- Bump solidus\_support to ~\> 0.6 [\#6](https://github.com/solidusio/solidus_webhooks/pull/6) ([peterberkenbosch](https://github.com/peterberkenbosch))
 
-## [v0.3.0](https://github.com/solidusio-contrib/solidus_webhooks/tree/v0.3.0) (2020-10-20)
+## [v0.3.0](https://github.com/solidusio/solidus_webhooks/tree/v0.3.0) (2020-10-20)
 
-[Full Changelog](https://github.com/solidusio-contrib/solidus_webhooks/compare/v0.2.0...v0.3.0)
+[Full Changelog](https://github.com/solidusio/solidus_webhooks/compare/v0.2.0...v0.3.0)
 
 **Fixed bugs:**
 
-- Fix error classes [\#5](https://github.com/solidusio-contrib/solidus_webhooks/pull/5) ([elia](https://github.com/elia))
+- Fix error classes [\#5](https://github.com/solidusio/solidus_webhooks/pull/5) ([elia](https://github.com/elia))
 
-## [v0.2.0](https://github.com/solidusio-contrib/solidus_webhooks/tree/v0.2.0) (2020-06-10)
+## [v0.2.0](https://github.com/solidusio/solidus_webhooks/tree/v0.2.0) (2020-06-10)
 
-[Full Changelog](https://github.com/solidusio-contrib/solidus_webhooks/compare/v0.1.0...v0.2.0)
+[Full Changelog](https://github.com/solidusio/solidus_webhooks/compare/v0.1.0...v0.2.0)
 
 **Implemented enhancements:**
 
-- Expose current\_api\_user to webhook handlers [\#4](https://github.com/solidusio-contrib/solidus_webhooks/pull/4) ([elia](https://github.com/elia))
+- Expose current\_api\_user to webhook handlers [\#4](https://github.com/solidusio/solidus_webhooks/pull/4) ([elia](https://github.com/elia))
 
-## [v0.1.0](https://github.com/solidusio-contrib/solidus_webhooks/tree/v0.1.0) (2020-05-14)
+## [v0.1.0](https://github.com/solidusio/solidus_webhooks/tree/v0.1.0) (2020-05-14)
 
-[Full Changelog](https://github.com/solidusio-contrib/solidus_webhooks/compare/v0.1.0.beta.1...v0.1.0)
+[Full Changelog](https://github.com/solidusio/solidus_webhooks/compare/v0.1.0.beta.1...v0.1.0)
 
-## [v0.1.0.beta.1](https://github.com/solidusio-contrib/solidus_webhooks/tree/v0.1.0.beta.1) (2020-05-13)
+## [v0.1.0.beta.1](https://github.com/solidusio/solidus_webhooks/tree/v0.1.0.beta.1) (2020-05-13)
 
-[Full Changelog](https://github.com/solidusio-contrib/solidus_webhooks/compare/v0.0.1.v0.1.0.beta.1.1...v0.1.0.beta.1)
+[Full Changelog](https://github.com/solidusio/solidus_webhooks/compare/v0.0.1.v0.1.0.beta.1.1...v0.1.0.beta.1)
 
-## [v0.0.1.v0.1.0.beta.1.1](https://github.com/solidusio-contrib/solidus_webhooks/tree/v0.0.1.v0.1.0.beta.1.1) (2020-05-13)
+## [v0.0.1.v0.1.0.beta.1.1](https://github.com/solidusio/solidus_webhooks/tree/v0.0.1.v0.1.0.beta.1.1) (2020-05-13)
 
-[Full Changelog](https://github.com/solidusio-contrib/solidus_webhooks/compare/9573caa400232ffb44cde7f8cf907171a529ced3...v0.0.1.v0.1.0.beta.1.1)
+[Full Changelog](https://github.com/solidusio/solidus_webhooks/compare/9573caa400232ffb44cde7f8cf907171a529ced3...v0.0.1.v0.1.0.beta.1.1)
 
 **Merged pull requests:**
 
-- Prepare the repo to be moved to @solidusio-contrib [\#2](https://github.com/solidusio-contrib/solidus_webhooks/pull/2) ([elia](https://github.com/elia))
-- Add the ability to register and receive webhooks [\#1](https://github.com/solidusio-contrib/solidus_webhooks/pull/1) ([elia](https://github.com/elia))
+- Prepare the repo to be moved to @solidusio [\#2](https://github.com/solidusio/solidus_webhooks/pull/2) ([elia](https://github.com/elia))
+- Add the ability to register and receive webhooks [\#1](https://github.com/solidusio/solidus_webhooks/pull/1) ([elia](https://github.com/elia))
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Solidus Webhooks
 
-[![CircleCI](https://circleci.com/gh/solidusio-contrib/solidus_webhooks.svg?style=shield)](https://circleci.com/gh/solidusio-contrib/solidus_webhooks)
-[![codecov](https://codecov.io/gh/solidusio-contrib/solidus_webhooks/branch/master/graph/badge.svg)](https://codecov.io/gh/solidusio-contrib/solidus_webhooks)
+[![CircleCI](https://circleci.com/gh/solidusio/solidus_webhooks.svg?style=shield)](https://circleci.com/gh/solidusio/solidus_webhooks)
+[![codecov](https://codecov.io/gh/solidusio/solidus_webhooks/branch/master/graph/badge.svg)](https://codecov.io/gh/solidusio/solidus_webhooks)
 
 <!-- Explain what your extension does. -->
 

--- a/solidus_webhooks.gemspec
+++ b/solidus_webhooks.gemspec
@@ -9,12 +9,12 @@ Gem::Specification.new do |spec|
   spec.email = 'contact@solidus.io'
 
   spec.summary = 'Webhooks support for Solidus'
-  spec.homepage = 'https://github.com/solidusio-contrib/solidus_webhooks#readme'
+  spec.homepage = 'https://github.com/solidusio/solidus_webhooks#readme'
   spec.license = 'BSD-3-Clause'
 
   spec.metadata['homepage_uri'] = spec.homepage
-  spec.metadata['source_code_uri'] = 'https://github.com/solidusio-contrib/solidus_webhooks'
-  spec.metadata['changelog_uri'] = 'https://github.com/solidusio-contrib/solidus_webhooks/releases'
+  spec.metadata['source_code_uri'] = 'https://github.com/solidusio/solidus_webhooks'
+  spec.metadata['changelog_uri'] = 'https://github.com/solidusio/solidus_webhooks/releases'
 
   spec.required_ruby_version = Gem::Requirement.new('>= 2.5')
 


### PR DESCRIPTION
## Summary

Following up the recent move of this extension from solidusio-contrib GitHub organization to solidusio one.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
