### PR TITLE
Add missing dependency on solidus_api

### DIFF
--- a/solidus_webhooks.gemspec
+++ b/solidus_webhooks.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'solidus_api', ['>= 2.0.0', '< 5']
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 5']
   spec.add_dependency 'solidus_support', '~> 0.6'
 


### PR DESCRIPTION
## Summary

The development environment was not catching it because we depend on solidus in the Gemfile, and it depends on solidus_api. However, dependants using solidus_webhooks needed to add solidus_api or solidus_frontend (which depends on the former) to their list of dependencies.

We need a new patch release after this.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
